### PR TITLE
chore: add test for esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "url"
     ],
     "scripts": {
-        "test": "standard && nyc --reporter none mocha test/**/*.js && karma start --single-run --browsers ChromeHeadless,FirefoxHeadless .karma.config.js && nyc report --reporter=text --reporter=html && nyc check-coverage --lines 100 --branches 100 --statements 100 --functions 100",
+        "test": "standard && mocha --experimental-modules test/*.mjs && nyc --reporter none mocha test/**/*.js && karma start --single-run --browsers ChromeHeadless,FirefoxHeadless .karma.config.js && nyc report --reporter=text --reporter=html && nyc check-coverage --lines 100 --branches 100 --statements 100 --functions 100",
         "test-ci": "./node_modules/.bin/karma start .karma.config-ci.js",
         "benchmark": "node benchmark/benchmark.js"
     },

--- a/test/esm.test.mjs
+++ b/test/esm.test.mjs
@@ -1,0 +1,10 @@
+/* global describe, it */
+
+import slug from '../slug.js'
+import assert from 'assert'
+
+describe('esm wrapper', function () {
+  it('should slugify strings', function () {
+    assert.strictEqual(slug('foo bar baz'), 'foo-bar-baz')
+  })
+})


### PR DESCRIPTION
In Node.js, this works with `import` as an ESM module. Write a minimal
test to make sure it continues to work.