### PR TITLE
Make library compatible with React Native

### DIFF
--- a/slug.js
+++ b/slug.js
@@ -51,13 +51,31 @@
     throw new Error('String "' + str + '" reaches code believed to be unreachable; please open an issue at https://github.com/Trott/slug/issues/new')
   }
 
-  if (typeof window === 'undefined') {
+  if (typeof window !== 'undefined' && window.btoa) {
+    base64 = function (input) {
+      return btoa(unescape(encodeURIComponent(input)))
+    }
+  } else if (typeof Buffer !== 'undefined') {
     base64 = function (input) {
       return Buffer.from(input).toString('base64')
     }
   } else {
-    base64 = function (input) {
-      return btoa(unescape(encodeURIComponent(input)))
+    // Polyfill for environments that don't have any btoa or Buffer class (eg. React Native)
+    // Copied from https://github.com/davidchambers/Base64.js/blob/a121f75bb10c8dd5d557886c4b1069b31258d230/base64.js#L22
+    base64 = function(input) {
+      var str = unescape(encodeURIComponent(input + ''));
+      for (
+        var block, charCode, idx = 0, map = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=', output = '';
+        str.charAt (idx | 0) || (map = '=', idx % 1);
+        output += map.charAt (63 & block >> 8 - idx % 1 * 8)
+      ) {
+        charCode = str.charCodeAt (idx += 3 / 4);
+        if (charCode > 0xFF) {
+          throw new Error ("'btoa' failed: The string to be encoded contains characters outside of the Latin1 range.");
+        }
+        block = block << 8 | charCode;
+      }
+      return output;
     }
   }
 


### PR DESCRIPTION
The current code assumes that if a window object is available, then a btoa function is too, however this is not true in all JS environment (eg. React Native).

So this pull request adds a fallback when neither btoa nor Buffer are available (this class is also missing in RN). Since the btoa pollyfill is quite small, I think it makes sense to include directly. That will make the lib more robust over the long term by eliminating all third-party dependencies.

Fixes this bug in particular: https://github.com/laurent22/joplin/issues/3815