### PR TITLE
Make library compatible with React Native

### DIFF
--- a/test/react-native.test.js
+++ b/test/react-native.test.js
@@ -1,0 +1,27 @@
+/* global after, before, describe, it */
+
+// Only run in Node.js.
+if (typeof window === 'undefined') {
+  describe('React Native-like environment', function () {
+    let slug
+
+    before(function () {
+      global.window = {}
+      delete require.cache[require.resolve('../slug')]
+    })
+    after(function () {
+      delete global.window
+      delete require.cache[require.resolve('../slug')]
+    })
+    const assert = require('assert')
+
+    it('should work for window object with no btoa function', function () {
+      assert.strictEqual(window.btoa, undefined)
+      slug = require('../slug')
+      assert.strictEqual(slug('鳄梨'), '6boe5qko')
+      assert.strictEqual(slug(String.fromCodePoint(56714, 36991)), 'iombvw')
+      assert.strictEqual(slug(String.fromCodePoint(56714)), 'ia')
+      assert.strictEqual(slug(String.fromCodePoint(55296)), 'ia')
+    })
+  })
+}


### PR DESCRIPTION
The current code assumes that if a window object is available, then a btoa function is too, however this is not true in all JS environment (eg. React Native).

So this pull request adds a fallback when neither btoa nor Buffer are available (this class is also missing in RN). Since the btoa pollyfill is quite small, I think it makes sense to include directly. That will make the lib more robust over the long term by eliminating all third-party dependencies.

Fixes this bug in particular: https://github.com/laurent22/joplin/issues/3815