### PR TITLE
feat: add support for React Native

### DIFF
--- a/test/react-native.test.js
+++ b/test/react-native.test.js
@@ -1,0 +1,27 @@
+/* global after, before, describe, it */
+
+// Only run in Node.js.
+if (typeof window === 'undefined') {
+  describe('React Native-like environment', function () {
+    let slug
+
+    before(function () {
+      global.window = {}
+      delete require.cache[require.resolve('../slug')]
+    })
+    after(function () {
+      delete global.window
+      delete require.cache[require.resolve('../slug')]
+    })
+    const assert = require('assert')
+
+    it('should work for window object with no btoa function', function () {
+      assert.strictEqual(window.btoa, undefined)
+      slug = require('../slug')
+      assert.strictEqual(slug('鳄梨'), '6boe5qko')
+      assert.strictEqual(slug(String.fromCodePoint(56714, 36991)), 'iombvw')
+      assert.strictEqual(slug(String.fromCodePoint(56714)), 'ia')
+      assert.strictEqual(slug(String.fromCodePoint(55296)), 'ia')
+    })
+  })
+}


### PR DESCRIPTION
Accomodate React Native and other environments that might have neither
btoa nor Buffer.

Opening this to get a Sauce Labs run for IE11. It doesn't work from forks. Actual PR is in https://github.com/Trott/slug/pull/121