### PR TITLE
chore: drop support for Node.js 10.x

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x, 16.x]
+        node-version: [12.x, 14.x, 15.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
BREAKING CHANGE: Drop support for Node.js 10.x which is now EOL.