### PR TITLE
fix: enable characters composed of multiple code points in .extend()

### DIFF
--- a/slug.js
+++ b/slug.js
@@ -891,7 +891,18 @@
   }
 
   slug.extend = function (customMap) {
-    Object.assign(slug.charmap, customMap)
+    const keys = Object.keys(customMap)
+    const multi = {}
+    const single = {}
+    for (let i = 0; i < keys.length; i++) {
+      if (keys[i].length > 1) {
+        multi[keys[i]] = customMap[keys[i]]
+      } else {
+        single[keys[i]] = customMap[keys[i]]
+      }
+    }
+    Object.assign(slug.charmap, single)
+    Object.assign(slug.multicharmap, multi)
   }
 
   /* global define */

--- a/test/slug.test.js
+++ b/test/slug.test.js
@@ -943,6 +943,11 @@ describe('slug', function () {
     assert.strictEqual(slug('unicode ♥ is ☢'), 'unicode-love-is-radioactive')
   })
 
+  it('should handle multiple code point characters with .extend()', function () {
+    slug.extend({ फ़: 'fhqwhgads' })
+    assert.strictEqual(slug('फ़'), 'fhqwhgads')
+  })
+
   it('should ignore symbols if they are not in the charmap', function () {
     assert.strictEqual(slug('unicode ♥ is ☢'), 'unicode-is')
   })


### PR DESCRIPTION
Characters that require multiple code points to represent were not
working with .extend(). Now they are.