### PR TITLE
feat(341): add fallback option

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,4 +121,5 @@ slug.defaults.modes['pretty'] = {
     multicharmap: slug.multicharmap
     trim: true              
 };
+slug.defaults.fallback = true // convert input with base64 if slug cannot be generated
 ```

--- a/slug.js
+++ b/slug.js
@@ -87,8 +87,9 @@
 
   function slug (string, opts) {
     let result = slugify(string, opts)
+    const fallback = opts?.fallback ?? slug.defaults.fallback
     // If output is an empty string, try slug for base64 of string.
-    if (result === '') {
+    if (fallback !== false && result === '') {
       // Get rid of lone surrogates.
       let input = ''
       for (let i = 0; i < string.length; i++) {
@@ -854,7 +855,8 @@
         trim: true
       }
     },
-    multicharmap: slug.multicharmap
+    multicharmap: slug.multicharmap,
+    fallback: true
   }
 
   slug.reset = function () {

--- a/slug.js
+++ b/slug.js
@@ -87,9 +87,9 @@
 
   function slug (string, opts) {
     let result = slugify(string, opts)
-    const fallback = opts?.fallback ?? slug.defaults.fallback
+    const fallback = opts && opts.fallback !== undefined ? opts.fallback : slug.defaults.fallback
     // If output is an empty string, try slug for base64 of string.
-    if (fallback !== false && result === '') {
+    if (fallback === true && result === '') {
       // Get rid of lone surrogates.
       let input = ''
       for (let i = 0; i < string.length; i++) {

--- a/test/slug.test.js
+++ b/test/slug.test.js
@@ -1070,4 +1070,12 @@ describe('slug', function () {
       assert.strictEqual(slug('foo' + char + ' bar baz'), 'foo' + replacement.toLowerCase() + '-bar-baz', 'replacing \'' + char + '\'')
     }
   })
+
+  it('should use base64 fallback', function () {
+    assert.strictEqual(slug('=)'), 'psk')
+  })
+
+  it('should return empty result when fallback is disabled', function () {
+    assert.strictEqual(slug('=(', { fallback: false }), '')
+  })
 })


### PR DESCRIPTION
Adds `fallback` option (default: `true`) to bypass base64 fallback when slug could not be generated.

Related issue: #341 

Do I need to update anything else?