### PR TITLE
chore: remove AMD support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
                 "karma-mocha": "^2.0.1",
                 "mocha": "^10.0.0",
                 "nyc": "^15.0.1",
-                "requirejs": "^2.3.6",
                 "semantic-release": "^19.0.1",
                 "standard": "^17.0.0"
             }
@@ -1554,9 +1553,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001377",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001377.tgz",
-            "integrity": "sha512-I5XeHI1x/mRSGl96LFOaSk528LA/yZG3m3iQgImGujjO8gotd/DL8QaI1R1h1dg5ATeI2jqPblMpKq4Tr5iKfQ==",
+            "version": "1.0.30001378",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001378.tgz",
+            "integrity": "sha512-JVQnfoO7FK7WvU4ZkBRbPjaot4+YqxogSDosHv0Hv5mWpUESmN+UubMU6L/hGz8QlQ2aY5U0vR6MOs6j/CXpNA==",
             "dev": true,
             "funding": [
                 {
@@ -2180,9 +2179,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.221",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.221.tgz",
-            "integrity": "sha512-aWg2mYhpxZ6Q6Xvyk7B2ziBca4YqrCDlXzmcD7wuRs65pVEVkMT1u2ifdjpAQais2O2o0rW964ZWWWYRlAL/kw==",
+            "version": "1.4.224",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.224.tgz",
+            "integrity": "sha512-dOujC5Yzj0nOVE23iD5HKqrRSDj2SD7RazpZS/b/WX85MtO6/LzKDF4TlYZTBteB+7fvSg5JpWh0sN7fImNF8w==",
             "dev": true
         },
         "node_modules/emoji-regex": {
@@ -5431,9 +5430,9 @@
             }
         },
         "node_modules/npm": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-8.17.0.tgz",
-            "integrity": "sha512-tIcfZd541v86Sqrf+t/GW6ivqiT8b/2b3EAjNw3vRe+eVnL4mlkVwu17hjCOrsPVntLb5C6tQG4jPUE5Oveeyw==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-8.18.0.tgz",
+            "integrity": "sha512-G07/yKvNUwhwxYhk8BxcuDPB/4s+y755i6CnH3lf9LQBHP5siUx66WbuNGWEnN3xaBER4+IR3OWApKX7eBO5Dw==",
             "bundleDependencies": [
                 "@isaacs/string-locale-compare",
                 "@npmcli/arborist",
@@ -5557,12 +5556,12 @@
                 "npm-package-arg": "^9.1.0",
                 "npm-pick-manifest": "^7.0.1",
                 "npm-profile": "^6.2.0",
-                "npm-registry-fetch": "^13.3.0",
+                "npm-registry-fetch": "^13.3.1",
                 "npm-user-validate": "^1.0.1",
                 "npmlog": "^6.0.2",
                 "opener": "^1.5.2",
                 "p-map": "^4.0.0",
-                "pacote": "^13.6.1",
+                "pacote": "^13.6.2",
                 "parse-conflict-json": "^2.0.2",
                 "proc-log": "^2.0.1",
                 "qrcode-terminal": "^0.12.0",
@@ -5624,7 +5623,7 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/@npmcli/arborist": {
-            "version": "5.5.0",
+            "version": "5.6.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -5714,7 +5713,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/fs": {
-            "version": "2.1.1",
+            "version": "2.1.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -5727,7 +5726,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/git": {
-            "version": "3.0.1",
+            "version": "3.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -5793,7 +5792,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/move-file": {
-            "version": "2.0.0",
+            "version": "2.0.1",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -5990,7 +5989,7 @@
             "license": "MIT"
         },
         "node_modules/npm/node_modules/bin-links": {
-            "version": "3.0.1",
+            "version": "3.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -6034,7 +6033,7 @@
             }
         },
         "node_modules/npm/node_modules/cacache": {
-            "version": "16.1.1",
+            "version": "16.1.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -6711,7 +6710,7 @@
             }
         },
         "node_modules/npm/node_modules/libnpmexec": {
-            "version": "4.0.10",
+            "version": "4.0.11",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -6854,7 +6853,7 @@
             }
         },
         "node_modules/npm/node_modules/make-fetch-happen": {
-            "version": "10.2.0",
+            "version": "10.2.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -6917,7 +6916,7 @@
             }
         },
         "node_modules/npm/node_modules/minipass-fetch": {
-            "version": "2.1.0",
+            "version": "2.1.1",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -7136,7 +7135,7 @@
             }
         },
         "node_modules/npm/node_modules/normalize-package-data": {
-            "version": "4.0.0",
+            "version": "4.0.1",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
@@ -7147,7 +7146,7 @@
                 "validate-npm-package-license": "^3.0.4"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16"
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/npm/node_modules/npm-audit-report": {
@@ -7251,7 +7250,7 @@
             }
         },
         "node_modules/npm/node_modules/npm-registry-fetch": {
-            "version": "13.3.0",
+            "version": "13.3.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -7323,7 +7322,7 @@
             }
         },
         "node_modules/npm/node_modules/pacote": {
-            "version": "13.6.1",
+            "version": "13.6.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -7922,7 +7921,7 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/write-file-atomic": {
-            "version": "4.0.1",
+            "version": "4.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -7931,7 +7930,7 @@
                 "signal-exit": "^3.0.7"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16"
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/npm/node_modules/yallist": {
@@ -9107,19 +9106,6 @@
             "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
             "dev": true
         },
-        "node_modules/requirejs": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
-            "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==",
-            "dev": true,
-            "bin": {
-                "r_js": "bin/r.js",
-                "r.js": "bin/r.js"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -10264,9 +10250,9 @@
             }
         },
         "node_modules/uglify-js": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
-            "integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.0.tgz",
+            "integrity": "sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==",
             "dev": true,
             "optional": true,
             "bin": {
@@ -11889,9 +11875,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001377",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001377.tgz",
-            "integrity": "sha512-I5XeHI1x/mRSGl96LFOaSk528LA/yZG3m3iQgImGujjO8gotd/DL8QaI1R1h1dg5ATeI2jqPblMpKq4Tr5iKfQ==",
+            "version": "1.0.30001378",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001378.tgz",
+            "integrity": "sha512-JVQnfoO7FK7WvU4ZkBRbPjaot4+YqxogSDosHv0Hv5mWpUESmN+UubMU6L/hGz8QlQ2aY5U0vR6MOs6j/CXpNA==",
             "dev": true
         },
         "cardinal": {
@@ -12372,9 +12358,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.4.221",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.221.tgz",
-            "integrity": "sha512-aWg2mYhpxZ6Q6Xvyk7B2ziBca4YqrCDlXzmcD7wuRs65pVEVkMT1u2ifdjpAQais2O2o0rW964ZWWWYRlAL/kw==",
+            "version": "1.4.224",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.224.tgz",
+            "integrity": "sha512-dOujC5Yzj0nOVE23iD5HKqrRSDj2SD7RazpZS/b/WX85MtO6/LzKDF4TlYZTBteB+7fvSg5JpWh0sN7fImNF8w==",
             "dev": true
         },
         "emoji-regex": {
@@ -14755,9 +14741,9 @@
             "dev": true
         },
         "npm": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-8.17.0.tgz",
-            "integrity": "sha512-tIcfZd541v86Sqrf+t/GW6ivqiT8b/2b3EAjNw3vRe+eVnL4mlkVwu17hjCOrsPVntLb5C6tQG4jPUE5Oveeyw==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-8.18.0.tgz",
+            "integrity": "sha512-G07/yKvNUwhwxYhk8BxcuDPB/4s+y755i6CnH3lf9LQBHP5siUx66WbuNGWEnN3xaBER4+IR3OWApKX7eBO5Dw==",
             "dev": true,
             "requires": {
                 "@isaacs/string-locale-compare": "^1.1.0",
@@ -14808,12 +14794,12 @@
                 "npm-package-arg": "^9.1.0",
                 "npm-pick-manifest": "^7.0.1",
                 "npm-profile": "^6.2.0",
-                "npm-registry-fetch": "^13.3.0",
+                "npm-registry-fetch": "^13.3.1",
                 "npm-user-validate": "^1.0.1",
                 "npmlog": "^6.0.2",
                 "opener": "^1.5.2",
                 "p-map": "^4.0.0",
-                "pacote": "^13.6.1",
+                "pacote": "^13.6.2",
                 "parse-conflict-json": "^2.0.2",
                 "proc-log": "^2.0.1",
                 "qrcode-terminal": "^0.12.0",
@@ -14850,7 +14836,7 @@
                     "dev": true
                 },
                 "@npmcli/arborist": {
-                    "version": "5.5.0",
+                    "version": "5.6.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -14921,7 +14907,7 @@
                     }
                 },
                 "@npmcli/fs": {
-                    "version": "2.1.1",
+                    "version": "2.1.2",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -14930,7 +14916,7 @@
                     }
                 },
                 "@npmcli/git": {
-                    "version": "3.0.1",
+                    "version": "3.0.2",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -14977,7 +14963,7 @@
                     }
                 },
                 "@npmcli/move-file": {
-                    "version": "2.0.0",
+                    "version": "2.0.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -15113,7 +15099,7 @@
                     "dev": true
                 },
                 "bin-links": {
-                    "version": "3.0.1",
+                    "version": "3.0.2",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -15147,7 +15133,7 @@
                     }
                 },
                 "cacache": {
-                    "version": "16.1.1",
+                    "version": "16.1.2",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -15623,7 +15609,7 @@
                     }
                 },
                 "libnpmexec": {
-                    "version": "4.0.10",
+                    "version": "4.0.11",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -15726,7 +15712,7 @@
                     "dev": true
                 },
                 "make-fetch-happen": {
-                    "version": "10.2.0",
+                    "version": "10.2.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -15773,7 +15759,7 @@
                     }
                 },
                 "minipass-fetch": {
-                    "version": "2.1.0",
+                    "version": "2.1.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -15921,7 +15907,7 @@
                     }
                 },
                 "normalize-package-data": {
-                    "version": "4.0.0",
+                    "version": "4.0.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -16003,7 +15989,7 @@
                     }
                 },
                 "npm-registry-fetch": {
-                    "version": "13.3.0",
+                    "version": "13.3.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -16054,7 +16040,7 @@
                     }
                 },
                 "pacote": {
-                    "version": "13.6.1",
+                    "version": "13.6.2",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -16480,7 +16466,7 @@
                     "dev": true
                 },
                 "write-file-atomic": {
-                    "version": "4.0.1",
+                    "version": "4.0.2",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -17373,12 +17359,6 @@
             "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
             "dev": true
         },
-        "requirejs": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
-            "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==",
-            "dev": true
-        },
         "requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -18242,9 +18222,9 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
-            "integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.0.tgz",
+            "integrity": "sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==",
             "dev": true,
             "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
         "karma-mocha": "^2.0.1",
         "mocha": "^10.0.0",
         "nyc": "^15.0.1",
-        "requirejs": "^2.3.6",
         "semantic-release": "^19.0.1",
         "standard": "^17.0.0"
     },

--- a/slug.js
+++ b/slug.js
@@ -884,12 +884,7 @@
     defaultLocale = locales[locale] || {}
   }
 
-  /* global define */
-  // Be compatible with different module systems
-
-  if (typeof define !== 'undefined' && define.amd) { // AMD
-    define([], function () { return slug })
-  } else if (typeof module !== 'undefined' && module.exports) { // CommonJS
+  if (typeof module !== 'undefined' && module.exports) { // CommonJS
     module.exports = slug
   } else { // Script tag
     root.slug = slug

--- a/test/slug.test.js
+++ b/test/slug.test.js
@@ -948,23 +948,6 @@ describe('slug', function () {
     assert.strictEqual(slug(String.fromCodePoint(55296)), 'ia')
   })
 
-  it('should be able to be loaded via amd', function (done) {
-    const modulePath = inBrowser ? 'base/slug' : '../slug'
-    const requirejs = (inBrowser && window.requirejs) || require('requirejs')
-
-    if (!inBrowser) {
-      requirejs.config({
-        nodeRequire: require
-      })
-    }
-
-    requirejs([modulePath], function (amdSlug) {
-      // Use toString() to compare source code.
-      assert.deepStrictEqual(amdSlug.toString(), slug.toString())
-      done()
-    })
-  })
-
   it('should ignore inherited properties in multicharmap', function () {
     const multicharmapPrototype = { justin: 'this-just-in' }
     function Multicharmap () {


### PR DESCRIPTION
BREAKING CHANGE: Loading via AMD will no longer work out-of-the-box.