### PR TITLE
feat: add `remove` option field to playground

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
 			</fieldset>
 
 			 <fieldset style="display: flex; justify-content: flex-start; align-items: center">
-        <label for="remove">Remove chars (regex)</label>
-        /<input type="text" id="remove" name="remove" />/<br />
+        <label for="remove">Remove chars (regex)</label>&nbsp;
+        /<input type="text" id="remove" name="remove" placeholder="(?<= )((a)|(an)|(the))(?= )" />/<br />
         <label> <input type="checkbox" name="regex_g" /> g </label>
 
         <label> <input type="checkbox" name="regex_i" /> i </label>

--- a/index.html
+++ b/index.html
@@ -18,14 +18,6 @@
 				<input type="text" id="replacement" name="replacement" placeholder="-">
 			</fieldset>
 
-			 <fieldset style="display: flex; justify-content: flex-start; align-items: center">
-        <label for="remove">Remove chars (regex)</label>&nbsp;
-        /<input type="text" id="remove" name="remove" placeholder="(?<= )((a)|(an)|(the))(?= )" />/<br />
-        <label> <input type="checkbox" name="regex_g" /> g </label>
-
-        <label> <input type="checkbox" name="regex_i" /> i </label>
-      </fieldset>
-
 			<fieldset>
 			<label>
 				<input type="checkbox" name="lowercase" checked> Lowercase
@@ -43,6 +35,17 @@
 				<input type="checkbox" name="fallback" checked> Fallback
 			</label>
 			</fieldset>
+
+			<details>
+				<summary><h4>Advanced options</h4></summary>
+			 <fieldset style="display: flex; justify-content: flex-start; align-items: center">
+        <label for="remove">Remove chars (regex)</label>&nbsp;
+        /<input type="text" id="remove" name="remove" placeholder="(?<= )((a)|(an)|(the))(?= )" />/<br />
+        <label> <input type="checkbox" name="regex_g" /> g </label>
+
+        <label> <input type="checkbox" name="regex_i" /> i </label>
+      </fieldset>
+			</details>
 
       <input type="submit" value="Slug it">
 

--- a/index.html
+++ b/index.html
@@ -13,13 +13,18 @@
 				<input type="text" id="input" placeholder="An Apple computer" autofocus>
 			</fieldset>
 
-
-
 			<fieldset>
 				<label for="replacement">Replacement character</label>
 				<input type="text" id="replacement" name="replacement" placeholder="-">
 			</fieldset>
 
+			 <fieldset style="display: flex; justify-content: flex-start; align-items: center">
+        <label for="remove">Remove chars (regex)</label>
+        /<input type="text" id="remove" name="remove" />/<br />
+        <label> <input type="checkbox" name="regex_g" /> g </label>
+
+        <label> <input type="checkbox" name="regex_i" /> i </label>
+      </fieldset>
 
 			<fieldset>
 			<label>

--- a/playground.js
+++ b/playground.js
@@ -14,10 +14,19 @@ form.addEventListener('submit', function (e) {
   const trim = fd.get('trim')
   const fallback = fd.get('fallback')
 
+  const remove = fd.get('remove')
+  const regexG = fd.get('regex_g') === null ? '' : 'g'
+  const regexI = fd.get('regex_i') === null ? '' : 'i'
+
   const opts = {}
 
   if (replacement.length > 0) {
     opts.replacement = replacement
+  }
+
+  if (remove !== null && remove.length > 0) {
+    const regex = new RegExp(`/${remove}/${regexG}${regexI}`)
+    opts.remove = regex
   }
 
   opts.lower = lowercase !== null


### PR DESCRIPTION
- Create new RegExp from user input 
- "global" and "ignore case" flags are exposed as checkboxes to user
- Tested with simple regex like `/[aeiou]/gi` (remove vowels) or `/(?<= )((a)|(an)|(the))(?= )/gi` (remove a/an/the with both positive and negative lookahead for space character)