### PR TITLE
BREAKING CHANGE: throw on lone surrogates

### DIFF
--- a/test/browser-mock.test.js
+++ b/test/browser-mock.test.js
@@ -18,9 +18,10 @@ if (typeof window === 'undefined') {
     it('should work for window object with no btoa function', async function () {
       const slug = (await import('../slug.js?cachebustingbrowser')).default
       assert.strictEqual(slug('鳄梨'), '6boe5qko')
-      assert.strictEqual(slug(String.fromCodePoint(56714, 36991)), 'iombvw')
-      assert.strictEqual(slug(String.fromCodePoint(56714)), 'ia')
-      assert.strictEqual(slug(String.fromCodePoint(55296)), 'ia')
+      const errMsg = 'Error: slug() received a malformed string with lone surrogates'
+      assert.throws(() => slug(String.fromCodePoint(56714, 36991)), errMsg)
+      assert.throws(() => (slug(String.fromCodePoint(56714))), errMsg)
+      assert.throws(() => slug(String.fromCodePoint(55296)), errMsg)
     })
   })
 }

--- a/test/fuzz.test.js
+++ b/test/fuzz.test.js
@@ -25,16 +25,18 @@ describe('fuzz-testing slug', function () {
       return { fuzzyString: words.join(' '), codePoints }
     }
 
-    for (let i = 0; i < FUZZ_TESTS; i++) {
-      {
-        const theString = getString(MAX_BMP_CODE_POINT)
+    function runTest (maxCodePoint) {
+      const theString = getString(maxCodePoint)
+      if (theString.fuzzyString.isWellFormed()) {
         assert(slug(theString.fuzzyString), 'STRING: ' + theString.fuzzyString + '\nCODEPOINTS: ' + JSON.stringify(theString.codePoints))
+      } else {
+        assert.throws(() => { slug(theString.fuzzyString) }, 'slug() received a malformed string with lone surrogates', 'STRING: ' + theString.fuzzyString + '\nCODEPOINTS: ' + JSON.stringify(theString.codePoints))
       }
+    }
 
-      {
-        const theString = getString(MAX_CODE_POINT)
-        assert(slug(theString.fuzzyString), 'STRING: ' + theString.fuzzyString + '\nCODEPOINTS: ' + JSON.stringify(theString.codePoints))
-      }
+    for (let i = 0; i < FUZZ_TESTS; i++) {
+      runTest(MAX_BMP_CODE_POINT)
+      runTest(MAX_CODE_POINT)
     }
   })
 })

--- a/test/react-native.test.js
+++ b/test/react-native.test.js
@@ -19,9 +19,10 @@ if (typeof window === 'undefined') {
       assert.strictEqual(window.btoa, undefined)
       const slug = (await import('../slug.js?cachebustingreactnative')).default
       assert.strictEqual(slug('鳄梨'), '6boe5qko')
-      assert.strictEqual(slug(String.fromCodePoint(56714, 36991)), 'iombvw')
-      assert.strictEqual(slug(String.fromCodePoint(56714)), 'ia')
-      assert.strictEqual(slug(String.fromCodePoint(55296)), 'ia')
+      const errMsg = /^Error: slug\(\) received a malformed string with lone surrogates$/
+      assert.throws(() => slug(String.fromCodePoint(56714, 36991)), errMsg)
+      assert.throws(() => slug(String.fromCodePoint(56714)), errMsg)
+      assert.throws(() => slug(String.fromCodePoint(55296)), errMsg)
     })
   })
 }

--- a/test/slug.test.js
+++ b/test/slug.test.js
@@ -837,7 +837,7 @@ describe('slug', function () {
   })
 
   it('should replace no unicode when disabled', function () {
-    const charMap = '😹☢☠☤☣☭☯☮☏☔☎☀★☂☃✈✉✊'.split('')
+    const charMap = ['😹', '☢', '☠', '☤', '☣', '☭', '☯', '☮', '☏', '☔', '☎', '☀', '★', '☂', '☃', '✈', '✉', '✊']
     charMap.forEach(function (char) {
       assert.strictEqual(slug('foo ' + char + ' bar baz'), 'foo-bar-baz', 'replacing \'' + char + '\'')
     })
@@ -934,16 +934,16 @@ describe('slug', function () {
     assert.strictEqual(slug('unicode ♥ is ☢'), 'unicode-is')
   })
 
-  it('should ignore lone surrogates', function () {
-    assert.strictEqual(slug(String.fromCodePoint(56714, 36991)), 'iombvw')
+  it('should throw on lone surrogates', function () {
+    assert.throw(() => slug(String.fromCodePoint(56714, 36991)))
   })
 
-  it('should handle a lone low surrogate by itself', function () {
-    assert.strictEqual(slug(String.fromCodePoint(56714)), 'ia')
+  it('should throw on a lone low surrogate by itself', function () {
+    assert.throws(() => slug(String.fromCodePoint(56714)))
   })
 
-  it('should handle a lone high surrogate by itself', function () {
-    assert.strictEqual(slug(String.fromCodePoint(55296)), 'ia')
+  it('should throw on a lone high surrogate by itself', function () {
+    assert.throws(() => slug(String.fromCodePoint(55296)))
   })
 
   it('should ignore inherited properties in multicharmap', function () {


### PR DESCRIPTION
Malformed strings will now throw. Strings must be well-formed. Specifically, we throw on lone surrogates.