### PR TITLE
fix: preserve a multi-character replacement so slug stays idempotent

### DIFF
--- a/slug.js
+++ b/slug.js
@@ -109,9 +109,14 @@ function slugify (string, opts) {
         char = localeMap[char]
       } else if (opts.charmap[char]) {
         char = opts.charmap[char].replace(opts.replacement, ' ')
-      } else if (char.includes(opts.replacement)) {
-        // preserve the replacement character in case it is excluded by disallowedChars
-        char = char.replace(opts.replacement, ' ')
+      } else if (
+        opts.replacement.length > 0 &&
+        string.substr(i, opts.replacement.length) === opts.replacement
+      ) {
+        // preserve an existing replacement (e.g. when re-slugifying), even when
+        // it is longer than one character or excluded by disallowedChars
+        i += opts.replacement.length - 1
+        char = ' '
       } else {
         char = char.replace(disallowedChars, '')
       }

--- a/test/slug.test.js
+++ b/test/slug.test.js
@@ -22,6 +22,11 @@ describe('slug', function () {
     assert.strictEqual(slug('foo  bar--baz'), 'foo-bar-baz')
   })
 
+  it('should be idempotent with a multi-character replacement', function () {
+    assert.strictEqual(slug('foo bar', { replacement: '__' }), 'foo__bar')
+    assert.strictEqual(slug(slug('foo bar', { replacement: '__' }), { replacement: '__' }), 'foo__bar')
+  })
+
   it('should remove trailing space if any', function () { assert.strictEqual(slug(' foo bar baz '), 'foo-bar-baz') })
 
   it('should preserve leading/trailing replacement characters if option set', function () {


### PR DESCRIPTION
### Problem

`slug` preserves a replacement string that is already present in the input, so that re-slugifying an existing slug is a no-op (idempotent). That preservation only works for a single-character replacement, because it tests `char.includes(opts.replacement)` against one code unit at a time, which can never match a replacement longer than one character.

As a result a multi-character replacement is treated as disallowed punctuation and stripped:

```js
const slug = require('slug')

slug('foo bar', { replacement: '__' })                              // 'foo__bar'
slug(slug('foo bar', { replacement: '__' }), { replacement: '__' }) // 'foobar'  <- separators lost
```

A single-character replacement round-trips correctly (`'_'` → idempotent), so this is an inconsistency rather than intended behavior. The README documents `replacement` as an arbitrary string with no single-character restriction.

### Fix

Detect the replacement with a fixed-length look-ahead and advance past it, mirroring the existing `multicharmap` handling (`i += len - 1`). This preserves a replacement of any length while leaving single-character and empty replacements unchanged.

### Test

Added an idempotence assertion for a multi-character replacement. It fails before the change and passes after. The full test suite is green and `c8 --100` coverage is preserved (100%).